### PR TITLE
patched empire module

### DIFF
--- a/cryton/hive/models/step.py
+++ b/cryton/hive/models/step.py
@@ -1268,7 +1268,6 @@ class StepExecutionEmpireAgentDeploy(StepExecution):
         try:
             step_arguments = self.update_step_arguments(self.step_instance.arguments, plan_execution_id)
             session_id = self.get_msf_session_id(self.step_instance, plan_execution_id)
-            #session_id = str(session_id)
         except (exceptions.SessionIsNotOpen, exceptions.MissingValueError) as ex:
             self.state = states.ERROR
             self.output = str(ex)

--- a/cryton/hive/models/step.py
+++ b/cryton/hive/models/step.py
@@ -1278,7 +1278,7 @@ class StepExecutionEmpireAgentDeploy(StepExecution):
             step_arguments[constants.SESSION_ID] = session_id
 
         if (session_id := step_arguments.get(constants.SESSION_ID)) is not None:
-            step_arguments[constants.SESSION_ID] = str(int(session_id))
+            step_arguments[constants.SESSION_ID] = int(session_id)
 
         message_body = {constants.STEP_TYPE: self.step_instance.step_type, constants.ARGUMENTS: step_arguments}
 

--- a/cryton/hive/models/step.py
+++ b/cryton/hive/models/step.py
@@ -1268,6 +1268,7 @@ class StepExecutionEmpireAgentDeploy(StepExecution):
         try:
             step_arguments = self.update_step_arguments(self.step_instance.arguments, plan_execution_id)
             session_id = self.get_msf_session_id(self.step_instance, plan_execution_id)
+            #session_id = str(session_id)
         except (exceptions.SessionIsNotOpen, exceptions.MissingValueError) as ex:
             self.state = states.ERROR
             self.output = str(ex)
@@ -1278,7 +1279,7 @@ class StepExecutionEmpireAgentDeploy(StepExecution):
             step_arguments[constants.SESSION_ID] = session_id
 
         if (session_id := step_arguments.get(constants.SESSION_ID)) is not None:
-            step_arguments[constants.SESSION_ID] = int(session_id)
+            step_arguments[constants.SESSION_ID] = str(int(session_id))
 
         message_body = {constants.STEP_TYPE: self.step_instance.step_type, constants.ARGUMENTS: step_arguments}
 

--- a/cryton/worker/empire.py
+++ b/cryton/worker/empire.py
@@ -230,7 +230,7 @@ async def deploy_agent(arguments: dict) -> dict:
     if session_id:
         metasploit_obj = MetasploitClientUpdated()
         try:
-            session_to_use = metasploit_obj.sessions.get(session_id)
+            session_to_use = metasploit_obj.sessions.get(int(session_id))
         except MSFError as ex:
             logger.logger.error("MSF session not found.", session_id=session_id)
             return {co.OUTPUT: f"MSF Session with id {session_id} not found. {ex}", co.RESULT: co.CODE_ERROR}
@@ -240,7 +240,7 @@ async def deploy_agent(arguments: dict) -> dict:
         logger.logger.debug(
             "Deploying agent via MSF session.", session_id=session_id, payload=payload, target_ip=target_ip
         )
-        session_to_use.execute_in_shell(payload)
+        session_to_use.execute_in_shell(executable=''.join(payload.split()[:1]).strip(), arguments=payload.split()[1:])
 
     elif ssh_connection:
         # Check if 'target' is in ssh_connection arguments

--- a/cryton/worker/empire.py
+++ b/cryton/worker/empire.py
@@ -230,7 +230,7 @@ async def deploy_agent(arguments: dict) -> dict:
     if session_id:
         metasploit_obj = MetasploitClientUpdated()
         try:
-            session_to_use = metasploit_obj.sessions.get(int(session_id))
+            session_to_use = metasploit_obj.sessions.get(session_id)
         except MSFError as ex:
             logger.logger.error("MSF session not found.", session_id=session_id)
             return {co.OUTPUT: f"MSF Session with id {session_id} not found. {ex}", co.RESULT: co.CODE_ERROR}
@@ -240,7 +240,9 @@ async def deploy_agent(arguments: dict) -> dict:
         logger.logger.debug(
             "Deploying agent via MSF session.", session_id=session_id, payload=payload, target_ip=target_ip
         )
-        session_to_use.execute_in_shell(executable=''.join(payload.split()[:1]).strip(), arguments=payload.split()[1:])
+
+        payload_tmp = payload.split()
+        session_to_use.execute_in_shell(executable=payload_tmp[0], arguments=payload_tmp[1:])
 
     elif ssh_connection:
         # Check if 'target' is in ssh_connection arguments

--- a/cryton/worker/task.py
+++ b/cryton/worker/task.py
@@ -263,7 +263,7 @@ class AgentTask(Task):
                 co.ACK_QUEUE: str,
                 co.STEP_TYPE: co.STEP_TYPE_DEPLOY_AGENT,
                 co.ARGUMENTS: {
-                    SchemaOptional(co.SESSION_ID): str,
+                    SchemaOptional(co.SESSION_ID): int,
                     SchemaOptional(co.USE_NAMED_SESSION): str,
                     SchemaOptional(co.USE_ANY_SESSION_TO_TARGET): str,
                     SchemaOptional(co.SSH_CONNECTION): dict,


### PR DESCRIPTION
I am working with the Cryton version `tag 2.1.0`, prerequisites as docker; hive and worker installed on Kali with pipx.

Upon trying out the basic empire windows example, I got some errors indicating a typecast error, i.e. `Key 'session_id' error:\n11 should be instance of 'str'`. During patching I also encountered `"MSF session not found."`.

Solving that, the next encountered errors came from `deploy_agent`, in `session_to_use.execute_in_shell(payload)`: `SessionShell.execute_in_shell() missing 1 required positional argument: 'arguments'`. I looked at the msf wrapper code and adjusted accordingly.

I'm sure that my patch can be cleaned up a bit before merging, as I'm unfamiliar with the broad picture of the codebase.

